### PR TITLE
Add polling for stream

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,6 +47,9 @@
       }
     }
   ],
+  "settings": {
+    "import/core-modules": ["@wnyu/spinitron-sdk"]
+  },
   "env": {
     "es6": true,
     "node": true

--- a/app/api.ts
+++ b/app/api.ts
@@ -1,0 +1,55 @@
+import { SpinitronMetadata } from '@wnyu/spinitron-sdk';
+import { useCallback, useEffect, useState } from 'react';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+const throwIfResponseIsNotOk = (res: Response): Response => {
+  if (!res.ok) {
+    throw new Error(`Response status: ${res.status} ${res.statusText}`);
+  }
+  return res;
+};
+
+// Custom React hook to make authenticated requests to the configured API
+const useWNYUApi = <T>(
+  path: string,
+  params: URLSearchParams = new URLSearchParams(),
+): [T | null, () => void] => {
+  const [response, setResponse] = useState(null);
+
+  const fetchData = useCallback(() => {
+    setResponse(null);
+    const url = new URL(path, API_URL);
+    url.search = params.toString();
+    fetch(url)
+      .then(throwIfResponseIsNotOk)
+      .then((res) => res.json())
+      .then(setResponse)
+      /* eslint-disable-next-line no-console --
+       *
+       * This error should be handled more gracefully but currently error
+       * handling is not implemented across the repository
+       */
+      .catch((e) => console.error(e));
+    /* eslint-disable-next-line react-hooks/exhaustive-deps --
+     *
+     * fetch should not be a dependency, because although it or its internal
+     * state may change from render to render, such changes are not relevant:
+     * a change in the way we make a request should not trigger an API request
+     *
+     * params is a dependency, but as an object - and often a newly-created
+     * object - depending on it directly causes spurious renders; instead, use
+     * its string value, which should be stable
+     */
+  }, [path, params.toString()]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return [response, fetchData];
+};
+
+const useMetadata = () => useWNYUApi<SpinitronMetadata>('/metadata');
+
+export { useMetadata };

--- a/app/types/MetaData.ts
+++ b/app/types/MetaData.ts
@@ -1,5 +1,0 @@
-interface MetaData {
-  metadata: string;
-}
-
-export type { MetaData };

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -1,1 +1,0 @@
-export * from './MetaData';

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@heroicons/react": "^2.1.5",
+        "@wnyu/spinitron-sdk": "^1.0.3",
         "next": "14.2.5",
         "react": "^18",
         "react-dom": "^18"
@@ -20,7 +21,6 @@
         "@types/react-dom": "^18",
         "@typescript-eslint/eslint-plugin": "^7.17.0",
         "@typescript-eslint/parser": "^7.17.0",
-        "@wnyu/spinitron-sdk": "^1.0.2",
         "eslint": "^8",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-airbnb-typescript": "^18.0.0",
@@ -714,10 +714,9 @@
       "dev": true
     },
     "node_modules/@wnyu/spinitron-sdk": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@wnyu/spinitron-sdk/-/spinitron-sdk-1.0.2.tgz",
-      "integrity": "sha512-rqHN6p0z5A1mdUu4lOA6mZ4QTDfAXGhCFdpV0h4q7jRU/a0A4o/V5/701/XF159Ob4q/F87qYZLejgfEzIP/lQ==",
-      "dev": true
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@wnyu/spinitron-sdk/-/spinitron-sdk-1.0.3.tgz",
+      "integrity": "sha512-21KRQVHoIfPIeMNKGf0qOtN/h8stVC+wKx9l1WNgXnMIGoCf4C7b0P67OAZ4aF6Yq0VGSHhHM82l5byVQyYQ6A=="
     },
     "node_modules/acorn": {
       "version": "8.12.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.1.5",
+    "@wnyu/spinitron-sdk": "^1.0.3",
     "next": "14.2.5",
     "react": "^18",
     "react-dom": "^18"
@@ -23,7 +24,6 @@
     "@types/react-dom": "^18",
     "@typescript-eslint/eslint-plugin": "^7.17.0",
     "@typescript-eslint/parser": "^7.17.0",
-    "@wnyu/spinitron-sdk": "^1.0.2",
     "eslint": "^8",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-airbnb-typescript": "^18.0.0",


### PR DESCRIPTION
This commit adds a polling system to the stream component, which queries our proxy api every five seconds for the latest stream data. It does this via a custom react hook, defined in the new api.ts folder. This was directly referenced from the pdc front-end repository, thanks to @slifty and @reefdog for their excellent documentation. It also adds the @wnyu/spinitron-sdk as a core module in the eslintrc file, as it was throwing an error for some reason

Closes #35 