### PR TITLE
Add show tiles to schedule page

### DIFF
--- a/app/(pages)/layout.tsx
+++ b/app/(pages)/layout.tsx
@@ -12,7 +12,7 @@ export default function AppLayout({
       <CurrentDataProvider>
         <DropdownToggleProvider>
           <Navbar>
-            <main className="mt-40">{children}</main>
+            <main className="mt-20">{children}</main>
           </Navbar>
         </DropdownToggleProvider>
       </CurrentDataProvider>

--- a/app/(pages)/schedule/page.tsx
+++ b/app/(pages)/schedule/page.tsx
@@ -1,4 +1,4 @@
-import ScheduleGrid from '../../components/SchedulePanel';
+import SchedulePanel from '../../components/SchedulePanel';
 import type { ShowsResponse } from '@wnyu/spinitron-sdk';
 
 // We prefetch all shows to get the schedule, but by default the shows
@@ -27,13 +27,13 @@ async function getData(): Promise<ShowsResponse> {
 async function ScheduleProvider() {
   const shows = await getData();
 
-  return <ScheduleGrid shows={shows.items} />;
+  return <SchedulePanel shows={shows.items} />;
 }
 
 export default async function Page() {
   return (
-    <>
+    <div className="md:fixed">
       <ScheduleProvider />
-    </>
+    </div>
   );
 }

--- a/app/components/DropDownPanel.tsx
+++ b/app/components/DropDownPanel.tsx
@@ -14,7 +14,7 @@ export default function DropDownPanel() {
   return (
     <div
       onClick={handleClick}
-      className={`fixed left-0 top-[72px] h-[calc(100vh-72px)] w-full overflow-y-auto bg-black transition-transform duration-500 ${
+      className={`fixed left-0 top-[72px] z-40 h-[calc(100vh-72px)] w-full overflow-y-auto bg-black transition-transform duration-500 ${
         context?.toggle ? 'translate-y-0' : '-translate-y-full'
       } md:-translate-y-full`}
     >

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -40,7 +40,7 @@ export default function Navbar({
     <>
       <div className="fixed left-0 right-0 top-0 z-50 w-full bg-white">
         <div
-          className={`flex border-b-2 p-4 transition-colors ease-in-out md:p-6 ${
+          className={`flex border-b-2 border-black p-4 transition-colors ease-in-out md:p-6 ${
             context?.toggle ? 'bg-black text-white' : 'bg-white'
           } md:bg-white md:text-black`}
         >

--- a/app/components/ScheduleItem.tsx
+++ b/app/components/ScheduleItem.tsx
@@ -1,28 +1,43 @@
 'use client';
 
+import { ShowCard } from './ShowCard';
 import type { Show } from '@wnyu/spinitron-sdk';
 import type { Dispatch, SetStateAction } from 'react';
 
 interface ScheduleItemProps {
   show: Show;
+  activeShowId?: number;
+  toggleScheduleDisplay: boolean;
   setActiveShowId: Dispatch<SetStateAction<number | undefined>>;
 }
 export default function ScheduleItem({
   show,
+  activeShowId,
+  toggleScheduleDisplay,
   setActiveShowId,
 }: ScheduleItemProps) {
   const handleClick = () => {
     setActiveShowId(show.id);
   };
+  if (toggleScheduleDisplay) {
+    return (
+      <ShowCard
+        show={show}
+        activeShowId={activeShowId}
+        handleClick={handleClick}
+      />
+    );
+  }
+
   return (
     <div
-      className="mx-3 border-2 border-neutral-950 p-5"
+      className={`mx-3 cursor-pointer p-5 ${activeShowId === show.id ? 'text-gray-400' : ''} transition-colors hover:text-gray-400`}
       key={show.id}
       onClick={handleClick}
     >
-      <p>{show.title}</p>
-      <p>{show.personas?.[0]?.name}</p>
-      <div>
+      <div className="text-4xl font-extrabold">{show.title}</div>
+      <div className="text-lg">hosted by {show.personas?.[0]?.name}</div>
+      <div className="text-lg">
         {new Date(show.start).toLocaleTimeString()} {' - '}
         {new Date(show.end).toLocaleTimeString()}
       </div>

--- a/app/components/ScheduleList.tsx
+++ b/app/components/ScheduleList.tsx
@@ -8,6 +8,8 @@ import type { Dispatch, SetStateAction } from 'react';
 
 interface ScheduleListProps {
   shows: Show[];
+  activeShowId?: number;
+  toggleScheduleDisplay: boolean;
   setActiveShowId: Dispatch<SetStateAction<number | undefined>>;
 }
 
@@ -23,6 +25,8 @@ const daysOfWeek = [
 
 export default function ScheduleList({
   shows,
+  activeShowId,
+  toggleScheduleDisplay,
   setActiveShowId,
 }: ScheduleListProps) {
   const [filteredShows, setFilteredShows] = useState<Show[]>([]);
@@ -49,9 +53,8 @@ export default function ScheduleList({
   }, [dayFilter, nameFilter, shows]);
 
   return (
-    <>
-      <h1>Schedule</h1>
-      <div>
+    <div className="w-full">
+      <div className="overflow-x-scroll md:flex">
         <div className="flex">
           <MagnifyingGlassIcon className="size-6" />
           <input
@@ -63,20 +66,26 @@ export default function ScheduleList({
         {daysOfWeek.map((day) => (
           <div
             key={day}
-            className={`cursor-pointer px-3 py-1 ${dayFilter === day ? 'text-black' : 'text-gray-200'}`}
+            className={`cursor-pointer px-3 py-1 text-lg font-bold ${dayFilter === day ? 'text-black' : 'text-gray-200'}`}
             onClick={() => setDayFilter(day)}
           >
             {day}
           </div>
         ))}
       </div>
-      {filteredShows.map((show) => (
-        <ScheduleItem
-          show={show}
-          key={show.id}
-          setActiveShowId={setActiveShowId}
-        />
-      ))}
-    </>
+      <div
+        className={`max-h-[800px] overflow-y-auto ${toggleScheduleDisplay ? 'md:mx-20 md:grid md:grid-cols-2 md:gap-y-10' : ''}`}
+      >
+        {filteredShows.map((show) => (
+          <ScheduleItem
+            show={show}
+            key={show.id}
+            setActiveShowId={setActiveShowId}
+            activeShowId={activeShowId}
+            toggleScheduleDisplay={toggleScheduleDisplay}
+          />
+        ))}
+      </div>
+    </div>
   );
 }

--- a/app/components/SchedulePanel.tsx
+++ b/app/components/SchedulePanel.tsx
@@ -9,16 +9,28 @@ interface ScheduleListProps {
   shows: Show[];
 }
 
-export default function ScheduleGrid({ shows }: ScheduleListProps) {
+export default function SchedulePanel({ shows }: ScheduleListProps) {
   const [activeShowId, setActiveShowId] = useState<number>();
+  const [toggleScheduleDisplay, setToggleScheduleDisplay] = useState(false);
 
   return (
-    <div className="flex flex-col lg:flex-row lg:space-x-4">
-      <div className="w-full lg:w-2/3">
-        <ScheduleList shows={shows} setActiveShowId={setActiveShowId} />
+    <div className="md:grid md:grid-cols-3">
+      <div className="md:col-span-2">
+        <ScheduleList
+          shows={shows}
+          setActiveShowId={setActiveShowId}
+          activeShowId={activeShowId}
+          toggleScheduleDisplay={toggleScheduleDisplay}
+        />
       </div>
-      <div className="w-full lg:w-1/3">
-        <ShowDetail show={shows.find((show) => show.id === activeShowId)} />
+      <div className="md:col-start-3">
+        {activeShowId && (
+          <ShowDetail
+            show={shows.find((show) => show.id === activeShowId)}
+            toggleScheduleDisplay={toggleScheduleDisplay}
+            setToggleScheduleDisplay={setToggleScheduleDisplay}
+          />
+        )}
       </div>
     </div>
   );

--- a/app/components/ShowCard.tsx
+++ b/app/components/ShowCard.tsx
@@ -1,0 +1,32 @@
+import { Show } from '@wnyu/spinitron-sdk';
+import Image from 'next/image';
+
+interface ShowCardProps {
+  show: Show;
+  activeShowId?: number;
+  handleClick?: () => void;
+}
+
+export function ShowCard({ show, activeShowId, handleClick }: ShowCardProps) {
+  return (
+    <div
+      className="group relative z-10 h-[150px] w-[200px] border-2 border-black bg-gray-500 text-white md:h-[300px] md:w-[400px]"
+      onClick={handleClick}
+    >
+      <Image
+        src={show.image}
+        alt={`${show.title} cover image`}
+        fill
+        className={`object-cover transition-all ease-in-out group-hover:brightness-0 ${activeShowId === show.id ? 'bg-black brightness-0' : ''}`}
+      />
+      <div className="absolute bottom-10 mx-4">
+        <div className="text-4xl font-extrabold">{show.title}</div>
+        <div className="text-lg">hosted by {show.personas?.[0]?.name}</div>
+        <div className="text-lg">
+          {new Date(show.start).toLocaleTimeString()} {' - '}
+          {new Date(show.end).toLocaleTimeString()}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/ShowDetail.tsx
+++ b/app/components/ShowDetail.tsx
@@ -1,21 +1,50 @@
+import { ArrowsPointingOutIcon } from '@heroicons/react/24/solid';
 import Image from 'next/image';
+import { trimSpinitronDescriptionString } from '../utils';
 import type { Show } from '@wnyu/spinitron-sdk';
+import type { Dispatch, SetStateAction } from 'react';
 
 interface ShowDetailProps {
   show: Show;
+  toggleScheduleDisplay: boolean;
+  setToggleScheduleDisplay: Dispatch<SetStateAction<boolean>>;
 }
 
-export default function ShowDetail({ show }: ShowDetailProps) {
+export default function ShowDetail({
+  show,
+  toggleScheduleDisplay,
+  setToggleScheduleDisplay,
+}: ShowDetailProps) {
+  const handleClick = () => {
+    setToggleScheduleDisplay(!toggleScheduleDisplay);
+  };
+
   return (
-    <div>
-      <Image src={show.image} width={500} height={500} alt="show image" />
-      <div>{show.title}</div>
-      <div>Hosted By: {show.personas?.[0].name}</div>
+    <div className="mx-10 h-[800px] overflow-y-auto">
       <div>
-        {new Date(show.start).toLocaleTimeString()} {' - '}
-        {new Date(show.end).toLocaleTimeString()}
+        <Image
+          src={show.image}
+          width={500}
+          height={500}
+          alt="show image"
+          className="border-2 border-black object-cover"
+        />
+        <div className="text-4xl font-extrabold">{show.title}</div>
+        <div className="text-lg">
+          hosted by: {show.personas?.[0].name ?? 'unhosted'}
+        </div>
+        <div className="text-lg">
+          {new Date(show.start).toLocaleTimeString()} {' - '}
+          {new Date(show.end).toLocaleTimeString()}
+        </div>
       </div>
-      <div>{show.description}</div>
+      <div className="mt-4">
+        {trimSpinitronDescriptionString(show.description)}
+      </div>
+      <ArrowsPointingOutIcon
+        onClick={handleClick}
+        className="mt-4 size-6 cursor-pointer transition-colors hover:text-gray-400"
+      />
     </div>
   );
 }

--- a/app/components/ShowDetailPanel.tsx
+++ b/app/components/ShowDetailPanel.tsx
@@ -1,14 +1,29 @@
 import ShowDetail from './ShowDetail';
 import type { Show } from '@wnyu/spinitron-sdk';
+import type { Dispatch, SetStateAction } from 'react';
 
 interface ShowDetailPanelProps {
   show?: Show;
+  toggleScheduleDisplay: boolean;
+  setToggleScheduleDisplay: Dispatch<SetStateAction<boolean>>;
 }
 
-export default function ShowDetailPanel({ show }: ShowDetailPanelProps) {
+export default function ShowDetailPanel({
+  show,
+  toggleScheduleDisplay,
+  setToggleScheduleDisplay,
+}: ShowDetailPanelProps) {
   return (
-    <div>
-      {show ? <ShowDetail show={show} /> : 'Select a radio show to see details'}
-    </div>
+    <>
+      {show && (
+        <div className="overflow-y-auto border-l-2 border-black bg-white">
+          <ShowDetail
+            show={show}
+            toggleScheduleDisplay={toggleScheduleDisplay}
+            setToggleScheduleDisplay={setToggleScheduleDisplay}
+          />
+        </div>
+      )}
+    </>
   );
 }

--- a/app/components/Stream.tsx
+++ b/app/components/Stream.tsx
@@ -19,9 +19,7 @@ export default function Stream() {
           .then(() => {
             setIsPlaying(true);
           })
-          .catch((error) => {
-            console.error('Error playing the audio stream:', error);
-          });
+          .catch(() => {});
       }
     }
   };


### PR DESCRIPTION
This commit adds an alternative method of viewing the shows in the schedule, as a two-columned grid of show images which is selectable via the ShowDetailPanel in desktop mode. It does not currently function properly for mobile and will need to be tweaked further, once we get a proper mobile schedule layout mockup.

Issue #72-add-show-tiles-to-schedule-page