### PR TITLE
Add Sanity Cache Revalidation

### DIFF
--- a/app/(pages)/about/page.tsx
+++ b/app/(pages)/about/page.tsx
@@ -10,9 +10,11 @@ import type {
 export default async function About() {
   const cards = await sanityFetch<MANAGEMENT_CARDS_QUERYResult>({
     query: MANAGEMENT_CARDS_QUERY,
+    tags: ['managementCard'],
   });
   const aboutText = await sanityFetch<ABOUT_TEXT_QUERYResult>({
     query: ABOUT_TEXT_QUERY,
+    tags: ['about'],
   });
   return (
     <>

--- a/app/(pages)/home/page.tsx
+++ b/app/(pages)/home/page.tsx
@@ -7,6 +7,7 @@ import type { ANNOUNCEMENTS_QUERYResult } from '@/sanity.types';
 export default async function Home() {
   const announcements = await sanityFetch<ANNOUNCEMENTS_QUERYResult>({
     query: ANNOUNCEMENTS_QUERY,
+    tags: ['announcement'],
   });
   return (
     <div>

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,0 +1,31 @@
+import { revalidateTag } from 'next/cache';
+import { type NextRequest, NextResponse } from 'next/server';
+import { parseBody } from 'next-sanity/webhook';
+import { hookSecret } from '@/sanity/env';
+
+export async function POST(req: NextRequest) {
+  try {
+    const { body, isValidSignature } = await parseBody<{
+      _type: string;
+      slug?: string | undefined;
+    }>(req, hookSecret);
+
+    if (!isValidSignature) {
+      return new Response('Invalid Signature', { status: 401 });
+    }
+
+    if (!body?._type) {
+      return new Response('Bad Request', { status: 400 });
+    }
+
+    revalidateTag(body._type);
+    return NextResponse.json({
+      status: 200,
+      revalidated: true,
+      now: Date.now(),
+      body,
+    });
+  } catch (error: unknown) {
+    return new Response(error as BodyInit, { status: 500 });
+  }
+}

--- a/app/components/CurrentPlaylistInfo.tsx
+++ b/app/components/CurrentPlaylistInfo.tsx
@@ -49,7 +49,7 @@ export default function CurrentPlaylistInfo({
         <>
           <div className="w-full text-left">
             <p>NOW PLAYING:</p>
-            <div className="text-xl font-extrabold">
+            <div className="text-4xl font-extrabold">
               {metadata?.playlist_title ?? 'WNYU JUKEBOX'}
             </div>
             <div className="text-l font-light">

--- a/sanity/env.ts
+++ b/sanity/env.ts
@@ -6,6 +6,11 @@ export const dataset = assertValue(
   'Missing environment variable: NEXT_PUBLIC_SANITY_DATASET',
 );
 
+export const hookSecret = assertValue(
+  process.env.NEXT_PUBLIC_SANITY_HOOK_SECRET,
+  'Missing environment variable: NEXT_PUBLIC_SANITY_HOOK_SECRET',
+);
+
 export const projectId = assertValue(
   process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
   'Missing environment variable: NEXT_PUBLIC_SANITY_PROJECT_ID',


### PR DESCRIPTION
This commit adds a revalidation pattern via a new custom route, `api/revalidate`, and a sanity webhook. This modification enables on-demand cache revalidation whenever content is modified in the sanity content lake. This should reflect changes to our sanity data on the front-end immediately, or close enough

Closes #89 