### PR TITLE
Add Mobile Show Page

### DIFF
--- a/app/(pages)/shows/[showId]/page.tsx
+++ b/app/(pages)/shows/[showId]/page.tsx
@@ -1,0 +1,62 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import { trimSpinitronDescriptionString } from '@/app/utils';
+import type { Persona, PlaylistsResponse, Show } from '@wnyu/spinitron-sdk';
+
+export default async function Page({ params }: { params: { showId: string } }) {
+  const show = (await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/shows/${params.showId}`,
+    {
+      cache: 'force-cache',
+    },
+  ).then((res) => res.json())) as Show;
+  const persona: Persona = (await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/personas/${show.personas?.[0].id}?expand=personas`,
+    {
+      cache: 'force-cache',
+    },
+  ).then((res) => res.json())) as Persona;
+  const playlists: PlaylistsResponse = (await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/playlists?show_id=${params.showId}`,
+    {
+      cache: 'force-cache',
+    },
+  ).then((res) => res.json())) as PlaylistsResponse;
+  return (
+    <>
+      <div className="mx-auto max-w-[800px]">
+        <div className="mx-auto max-w-[85%]">
+          <Image
+            src={show.image || ''}
+            alt={` cover image`}
+            priority
+            width={500}
+            height={400}
+          />
+          <div className="text-4xl font-extrabold">{show.title}</div>
+          <div className="text-xl">{`hosted by ${persona.name}`}</div>
+          <div className="text-xl">
+            {new Date(show.start).toLocaleTimeString()} {' - '}
+            {new Date(show.end).toLocaleTimeString()}
+          </div>
+          <div className="mt-4 text-lg">
+            {trimSpinitronDescriptionString(show.description)}
+          </div>
+        </div>
+        <div className="mt-4 grid grid-cols-2 gap-4">
+          {playlists.items &&
+            playlists.items.map((playlist) => (
+              <div
+                className="mx-auto w-[175px] cursor-pointer border-4 border-black p-4 text-center text-sm font-bold transition-all hover:opacity-50"
+                key={playlist.id}
+              >
+                <Link href={`/playlists/${playlist.id}`}>
+                  {new Date(playlist.start).toDateString()}
+                </Link>
+              </div>
+            ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/components/ScheduleItem.tsx
+++ b/app/components/ScheduleItem.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import type { Show } from '@wnyu/spinitron-sdk';
 import type { Dispatch, SetStateAction } from 'react';
 
@@ -18,17 +19,32 @@ export default function ScheduleItem({
   };
 
   return (
-    <div
-      className={`mx-3 cursor-pointer p-5 ${activeShowId === show.id ? 'text-gray-400' : ''} transition-colors hover:text-gray-400`}
-      key={show.id}
-      onClick={handleClick}
-    >
-      <div className="text-4xl font-extrabold">{show.title}</div>
-      <div className="text-lg">hosted by {show.personas?.[0]?.name}</div>
-      <div className="text-lg">
-        {new Date(show.start).toLocaleTimeString()} {' - '}
-        {new Date(show.end).toLocaleTimeString()}
+    <>
+      <div
+        className={`mx-3 block cursor-pointer p-5 ${activeShowId === show.id ? 'text-gray-400' : ''} transition-colors hover:text-gray-400 md:hidden`}
+        key={show.id}
+      >
+        <Link href={`shows/${show.id}`}>
+          <div className="text-4xl font-extrabold">{show.title}</div>
+          <div className="text-lg">hosted by {show.personas?.[0]?.name}</div>
+          <div className="text-lg">
+            {new Date(show.start).toLocaleTimeString()} {' - '}
+            {new Date(show.end).toLocaleTimeString()}
+          </div>
+        </Link>
       </div>
-    </div>
+      <div
+        className={`mx-3 hidden cursor-pointer p-5 ${activeShowId === show.id ? 'text-gray-400' : ''} transition-colors hover:text-gray-400 md:block`}
+        key={show.id}
+        onClick={handleClick}
+      >
+        <div className="text-4xl font-extrabold">{show.title}</div>
+        <div className="text-lg">hosted by {show.personas?.[0]?.name}</div>
+        <div className="text-lg">
+          {new Date(show.start).toLocaleTimeString()} {' - '}
+          {new Date(show.end).toLocaleTimeString()}
+        </div>
+      </div>
+    </>
   );
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,6 +16,10 @@ const nextConfig = {
         protocol: 'https',
         hostname: '**.mzstatic.com',
       },
+      {
+        protocol: 'https',
+        hostname: 'spinitron.com',
+      },
     ],
   },
   experimental: {


### PR DESCRIPTION
This commit adds a show page, similarly to the playlist page, which is a dynamically rendered route that shows the playlists for a given show. Shows are accessed via the schedule and looked up via their spinitron id.

Closes #110 