### PR TITLE
Remove absolute site-wide positioning

### DIFF
--- a/app/(pages)/home/page.tsx
+++ b/app/(pages)/home/page.tsx
@@ -9,13 +9,14 @@ export default async function Home() {
     query: ANNOUNCEMENTS_QUERY,
     tags: ['announcement'],
   });
+
   return (
-    <div>
-      <div className="mx-7 flex-col space-y-10 md:mx-auto md:grid md:grid-cols-3 md:grid-rows-6 md:space-x-12 md:space-y-0">
+    <div className="static">
+      <div className="mx-7 flex flex-col space-y-10 md:mx-auto md:grid md:grid-cols-3 md:grid-rows-6 md:space-x-12 md:space-y-0">
         <div className="h-[200px] md:col-span-2 md:row-span-5 md:ml-8 md:h-auto">
           <AnnouncementsCarousel announcements={announcements} />
         </div>
-        <div className="sticky md:col-span-1 md:row-span-6">
+        <div className="md:col-span-1 md:row-span-6">
           <CurrentShowPanel />
         </div>
       </div>

--- a/app/(pages)/layout.tsx
+++ b/app/(pages)/layout.tsx
@@ -12,7 +12,7 @@ export default function AppLayout({
       <CurrentDataProvider>
         <DropdownToggleProvider>
           <Navbar>
-            <main className="absolute top-20">{children}</main>
+            <main className="pt-20">{children}</main>
           </Navbar>
         </DropdownToggleProvider>
       </CurrentDataProvider>

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -1,5 +1,10 @@
 function trimSpinitronDescriptionString(s: string) {
-  return s.slice(3, -4);
+  try {
+    const val = s.slice(3, -4);
+    return val;
+  } catch (err) {
+    return '';
+  }
 }
 
 export { trimSpinitronDescriptionString };


### PR DESCRIPTION
This emergency commit drops the site-wide absolute css tag from the app/(pages)/layout.tsx file. This was causing insane layout flush on mobile layouts. It also adds an error handler for the spinitron description utility function.