### PR TITLE
Improve stream user experience

### DIFF
--- a/app/components/Stream.tsx
+++ b/app/components/Stream.tsx
@@ -1,26 +1,30 @@
 'use client';
 
-import { useState, useRef } from 'react';
+import { useState, useRef, useContext } from 'react';
 import { PlayIcon, PauseIcon } from '@heroicons/react/24/solid';
+import { DropdownToggleContext } from '../providers/ToggleProvider';
 
 export default function Stream() {
   const [isPlaying, setIsPlaying] = useState(false);
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const context = useContext(DropdownToggleContext);
 
   const handleClick = () => {
     if (audioRef.current) {
       if (isPlaying) {
-        audioRef.current.pause();
         setIsPlaying(false);
+        audioRef.current.pause();
       } else {
+        setIsPlaying(true);
         audioRef.current.src = process.env.NEXT_PUBLIC_STREAM_URL as string;
         audioRef.current
           .play()
-          .then(() => {
-            setIsPlaying(true);
-          })
+          .then(() => {})
           .catch(() => {});
       }
+    }
+    if (context?.toggle === false) {
+      context?.setToggle(true);
     }
   };
 


### PR DESCRIPTION
This commit improves the stream component from a user experience pov by flipping the stream button as soon as a user presses it, rather than hanging on the stream load, and dropping the dropdown menu on play, which exposes it to users sooner.

Closes #194 