### PR TITLE
Add priority key for management cards

### DIFF
--- a/sanity/lib/queries.ts
+++ b/sanity/lib/queries.ts
@@ -6,7 +6,7 @@ export enum ARTICLE_TYPES {
   NEWS = 'news',
 }
 
-export const MANAGEMENT_CARDS_QUERY = groq`*[_type=="managementCard"]{'id':_id,name,role,email,picture}`;
+export const MANAGEMENT_CARDS_QUERY = groq`*[_type=="managementCard"]|order(priority asc){'id':_id,name,role,email,picture}`;
 
 export const MANAGEMENT_CARD_QUERY = groq`*[_type=="managementCard"][0]{'id':_id,name,role,email,picture}`;
 

--- a/sanity/schemaTypes/managementCardType.ts
+++ b/sanity/schemaTypes/managementCardType.ts
@@ -18,6 +18,10 @@ export const managementCardType = defineType({
       type: 'string',
     }),
     defineField({
+      name: 'priority',
+      type: 'number',
+    }),
+    defineField({
       name: 'picture',
       type: 'image',
       options: {


### PR DESCRIPTION
This commit adds a priority key for management cards to set the order that they're listed. They're in ascending order, so the smaller the priority value the earlier it'll appear in the about page

Closes #283 