### PR TITLE
Add framer motion for drop down menu

### DIFF
--- a/app/(pages)/about/page.tsx
+++ b/app/(pages)/about/page.tsx
@@ -18,7 +18,7 @@ export default async function About() {
   });
   return (
     <>
-      <div className="mx-8 pb-4 pt-20 md:mx-14 md:flex md:justify-between">
+      <div className="mx-8 pb-4 md:mx-14 md:flex md:justify-between">
         <div className="pr-1/4 prose mr-auto shrink-0 pb-4 pt-10 leading-5 md:w-1/2">
           {aboutText?.content ? (
             <PortableText value={aboutText.content} />

--- a/app/(pages)/sports/page.tsx
+++ b/app/(pages)/sports/page.tsx
@@ -28,9 +28,9 @@ export default async function Page() {
 
   return (
     <div className="static h-screen">
-      <div className="container mx-auto px-4 pt-10">
+      <div className="container mx-auto px-4">
         <div className="hidden flex-col md:flex md:flex-row">
-          <div className="w-full pr-4 pt-20 md:w-2/3">
+          <div className="w-full pr-4 pt-4 md:w-2/3">
             <ArticlesGroup articles={sportsArticles} />
           </div>
 
@@ -39,7 +39,7 @@ export default async function Page() {
           </div>
         </div>
         <div className="flex flex-col gap-8 md:hidden">
-          <div className="w-full pr-4 pt-20 md:w-2/3">
+          <div className="w-full pr-4 pt-4 md:w-2/3">
             <ArticlesGroup articles={sportsArticles} />
           </div>
           <h1 className="text-center text-6xl font-extrabold">Programs</h1>

--- a/app/components/AnnouncementsCarousel.tsx
+++ b/app/components/AnnouncementsCarousel.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import { Swiper, SwiperSlide } from 'swiper/react';
+import { Autoplay } from 'swiper/modules';
 import Image from 'next/image';
 import { urlFor } from '@/sanity/lib/image';
 import type { ANNOUNCEMENTS_QUERYResult } from '../../sanity.types';
 import 'swiper/css';
+import 'swiper/css/autoplay';
 
 export default function AnnouncementsCarousel({
   announcements,
@@ -15,6 +17,11 @@ export default function AnnouncementsCarousel({
     <Swiper
       spaceBetween={1}
       slidesPerView={1}
+      autoplay={{
+        delay: 3000,
+        disableOnInteraction: false,
+      }}
+      modules={[Autoplay]}
       className="h-full w-full border-4 border-black"
     >
       {announcements.map((announcement) => (
@@ -25,7 +32,7 @@ export default function AnnouncementsCarousel({
               .height(300)
               .url()}
             fill
-            className={`object-cover`}
+            className="object-cover"
             alt={announcement.title || ''}
           />
           <div className="absolute bottom-0 h-1/3 w-full bg-black text-white md:h-1/5">

--- a/app/components/DropDownPanel.tsx
+++ b/app/components/DropDownPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useContext } from 'react';
+import { motion } from 'framer-motion';
 import { DropdownToggleContext } from '../providers/ToggleProvider';
 import CurrentPlaylistPanel from './CurrentPlaylistPanel';
 
@@ -12,15 +13,16 @@ export default function DropDownPanel() {
   };
 
   return (
-    <div
+    <motion.div
       onClick={handleClick}
-      className={`fixed left-0 top-[50px] z-40 h-[calc(100vh)] w-full overflow-y-auto overflow-x-clip bg-black transition-transform duration-500 ${
-        context?.toggle ? 'translate-y-0' : '-translate-y-full'
-      } md:-translate-y-full`}
+      initial={{ y: '-100%' }}
+      animate={context?.toggle ? { y: 0 } : { y: '-100%' }}
+      transition={{ duration: 0.5, ease: 'easeInOut' }}
+      className="fixed left-0 top-[50px] z-40 h-[calc(100vh)] w-full overflow-y-auto overflow-x-clip bg-black"
     >
       <div className="p-6">
         <CurrentPlaylistPanel dropdown={true} />
       </div>
-    </div>
+    </motion.div>
   );
 }

--- a/app/components/NavMenu.tsx
+++ b/app/components/NavMenu.tsx
@@ -15,7 +15,13 @@ export default function NavMenu() {
     context?.setToggle(false);
   };
 
-  const handleXMarkClick = (e: React.MouseEvent<SVGSVGElement>) => {
+  const handleClose = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.stopPropagation();
+    setToggleMenu(false);
+    context?.setToggle(false);
+  };
+
+  const close = (e: React.MouseEvent<SVGSVGElement>) => {
     e.stopPropagation();
     setToggleMenu(false);
     context?.setToggle(false);
@@ -36,25 +42,25 @@ export default function NavMenu() {
           className="fixed left-0 top-0 z-40 flex h-auto w-full items-start justify-start overflow-y-auto bg-black p-4"
         >
           <div className="my-7 ml-7 flex flex-col space-y-7 text-3xl font-bold text-white">
-            <Link href="/home" onClick={handleClick}>
+            <Link href="/home" onClick={handleClose}>
               home
             </Link>
-            <Link href="/schedule" onClick={handleClick}>
+            <Link href="/schedule" onClick={handleClose}>
               schedule
             </Link>
-            <Link href="/about" onClick={handleClick}>
+            <Link href="/about" onClick={handleClose}>
               about
             </Link>
-            <Link href="/podcasts" onClick={handleClick}>
+            <Link href="/podcasts" onClick={handleClose}>
               podcasts
             </Link>
-            <Link href="/sports" onClick={handleClick}>
+            <Link href="/sports" onClick={handleClose}>
               sports
             </Link>
           </div>
           <XMarkIcon
             className="z-100 absolute right-0 top-0 size-14 text-white"
-            onClick={handleXMarkClick}
+            onClick={close}
           />
         </motion.div>
       </div>

--- a/app/components/NavMenu.tsx
+++ b/app/components/NavMenu.tsx
@@ -15,6 +15,12 @@ export default function NavMenu() {
     context?.setToggle(false);
   };
 
+  const handleXMarkClick = (e: React.MouseEvent<SVGSVGElement>) => {
+    e.stopPropagation();
+    setToggleMenu(false);
+    context?.setToggle(false);
+  };
+
   return (
     <>
       <div className="md:hidden">
@@ -47,8 +53,8 @@ export default function NavMenu() {
             </Link>
           </div>
           <XMarkIcon
-            className="absolute right-0 top-0 size-14 text-white"
-            onClick={handleClick}
+            className="z-100 absolute right-0 top-0 size-14 text-white"
+            onClick={handleXMarkClick}
           />
         </motion.div>
       </div>

--- a/app/components/NavMenu.tsx
+++ b/app/components/NavMenu.tsx
@@ -2,16 +2,16 @@
 
 import { useState, useContext } from 'react';
 import Link from 'next/link';
+import { motion } from 'framer-motion';
 import { EllipsisVerticalIcon, XMarkIcon } from '@heroicons/react/24/solid';
 import { DropdownToggleContext } from '../providers/ToggleProvider';
 
 export default function NavMenu() {
   const context = useContext(DropdownToggleContext);
-
   const [toggleMenu, setToggleMenu] = useState(false);
 
   const handleClick = () => {
-    setToggleMenu(!toggleMenu);
+    setToggleMenu((prev) => !prev);
     context?.setToggle(false);
   };
 
@@ -22,10 +22,12 @@ export default function NavMenu() {
           className="size-10 md:hidden"
           onClick={handleClick}
         />
-        <div
-          className={`fixed left-0 top-0 z-40 h-auto w-full overflow-y-auto bg-black p-4 transition-transform duration-500 ${
-            toggleMenu ? 'translate-y-0' : '-translate-y-full'
-          } flex items-start justify-start md:-translate-y-full`}
+        <motion.div
+          onClick={handleClick}
+          initial={{ y: '-100%' }}
+          animate={toggleMenu ? { y: 0 } : { y: '-100%' }}
+          transition={{ duration: 0.5, ease: 'easeInOut' }}
+          className="fixed left-0 top-0 z-40 flex h-auto w-full items-start justify-start overflow-y-auto bg-black p-4"
         >
           <div className="my-7 ml-7 flex flex-col space-y-7 text-3xl font-bold text-white">
             <Link href="/home" onClick={handleClick}>
@@ -48,7 +50,7 @@ export default function NavMenu() {
             className="absolute right-0 top-0 size-14 text-white"
             onClick={handleClick}
           />
-        </div>
+        </motion.div>
       </div>
       <div className="hidden flex-row items-end justify-end space-x-4 text-xl font-bold text-black md:flex">
         <Link href="/home">HOME</Link>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@sanity/image-url": "^1.1.0",
         "@sanity/vision": "^3.64.1",
         "@wnyu/spinitron-sdk": "^1.0.4",
+        "framer-motion": "^12.4.1",
         "next": "15.1.6",
         "next-sanity": "^9.8.46",
         "react": "^18",
@@ -9815,10 +9816,9 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.0.6",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.0.6.tgz",
-      "integrity": "sha512-LmrXbXF6Vv5WCNmb+O/zn891VPZrH7XbsZgRLBROw6kFiP+iTK49gxTv2Ur3F0Tbw6+sy9BVtSqnWfMUpH+6nA==",
-      "license": "MIT",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.4.1.tgz",
+      "integrity": "sha512-5Ijbea3topSZjadQ0hgc/TcWj2ldMZmNREM7RvAhvsThYOA1HHOA8TT1yKvMu1YXP3jWaFwoZ6Vo9Nw+DUZrzA==",
       "dependencies": {
         "motion-dom": "^12.0.0",
         "motion-utils": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@sanity/image-url": "^1.1.0",
     "@sanity/vision": "^3.64.1",
     "@wnyu/spinitron-sdk": "^1.0.4",
+    "framer-motion": "^12.4.1",
     "next": "15.1.6",
     "next-sanity": "^9.8.46",
     "react": "^18",


### PR DESCRIPTION
This PR switches the existing dropdown menu functionality with framer motion, which effectively is the same thing (i think, just a wrapper for css animations), but it allows us to cut down on the in-line tailwind css for animations. Also it adds a bunch of spacing fixes